### PR TITLE
Correct screen backing scale factor.

### DIFF
--- a/React/Base/RCTUtils.m
+++ b/React/Base/RCTUtils.m
@@ -202,19 +202,11 @@ void RCTExecuteOnMainThread(dispatch_block_t block, BOOL sync)
 
 CGFloat RCTScreenScale()
 {
-  static CGFloat scale;
-  scale = 1;
-  static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{
-    if (![NSThread isMainThread]) {
-      dispatch_sync(dispatch_get_main_queue(), ^{
-        scale = [NSScreen mainScreen].backingScaleFactor;
-      });
-    } else {
-      scale = [NSScreen mainScreen].backingScaleFactor;
-    }
-  });
-
+  static CGFloat scale = 1.0;
+  RCTExecuteOnMainThread(^{
+    scale = [NSScreen mainScreen].backingScaleFactor;
+  }, YES);
+  
   return scale;
 }
 


### PR DESCRIPTION
Previously, backing scale factor was hardcoded to 1, which caused `<Image />` displayed wrong on Retina monitors.
Also I remove `dispatch_once` so RND could adapt to dynamic backing scale factor changes. Unlike iOS devices, dynamic backing scale factor changes are possible. (For example, user with dual displays might drag a window from a Retina display to another non-Retina display.) With profiling, I found that removing `dispatch_once` won't cause noticeable performance issue, unless you have hundreds of  `<Image />` to display at the same time.