### PR TITLE
Expose accessibilityElement and accessibilityRole for better UI autom…

### DIFF
--- a/Libraries/Components/Touchable/TouchableBounce.js
+++ b/Libraries/Components/Touchable/TouchableBounce.js
@@ -134,6 +134,7 @@ var TouchableBounce = React.createClass({
         accessibilityComponentType={this.props.accessibilityComponentType}
         accessibilityTraits={this.props.accessibilityTraits}
         testID={this.props.testID}
+        testRole='AXTouchableBounce'
         hitSlop={this.props.hitSlop}
         onStartShouldSetResponder={this.touchableHandleStartShouldSetResponder}
         onResponderTerminationRequest={this.touchableHandleResponderTerminationRequest}

--- a/Libraries/Components/Touchable/TouchableHighlight.js
+++ b/Libraries/Components/Touchable/TouchableHighlight.js
@@ -245,8 +245,8 @@ var TouchableHighlight = React.createClass({
         onResponderMove={this.touchableHandleResponderMove}
         onResponderRelease={this.touchableHandleResponderRelease}
         onResponderTerminate={this.touchableHandleResponderTerminate}
-
         testID={this.props.testID}
+        testRole='AXTouchableHighlight'
         onMouseEnter={this.props.onMouseEnter}
         onMouseLeave={this.props.onMouseLeave}>
         {React.cloneElement(

--- a/Libraries/Components/Touchable/TouchableOpacity.js
+++ b/Libraries/Components/Touchable/TouchableOpacity.js
@@ -163,6 +163,7 @@ var TouchableOpacity = React.createClass({
         accessibilityTraits={this.props.accessibilityTraits}
         style={[this.props.style, {opacity: this.state.anim}]}
         testID={this.props.testID}
+        testRole='AXTouchableOpacity'
         onLayout={this.props.onLayout}
         hitSlop={this.props.hitSlop}
         onStartShouldSetResponder={this.touchableHandleStartShouldSetResponder}

--- a/Libraries/Components/View/ReactNativeViewAttributes.js
+++ b/Libraries/Components/View/ReactNativeViewAttributes.js
@@ -24,6 +24,7 @@ ReactNativeViewAttributes.UIView = {
   accessibilityTraits: true,
   importantForAccessibility: true,
   testID: true,
+  testRole: true,
   renderToHardwareTextureAndroid: true,
   shouldRasterizeIOS: true,
   onLayout: true,

--- a/Libraries/Components/View/View.js
+++ b/Libraries/Components/View/View.js
@@ -197,6 +197,12 @@ const View = React.createClass({
     testID: PropTypes.string,
 
     /**
+     * A nonlocalized string that defines the type of interface element represented
+     * by the accessibility element. Used in end-to-end tests.
+     */
+    testRole: PropTypes.string,
+
+    /**
      * For most touch interactions, you'll simply want to wrap your component in
      * `TouchableHighlight` or `TouchableOpacity`. Check out `Touchable.js`,
      * `ScrollResponder.js` and `ResponderEventPlugin.js` for more discussion.

--- a/Libraries/Text/Text.js
+++ b/Libraries/Text/Text.js
@@ -98,6 +98,11 @@ const Text = React.createClass({
      */
     testID: React.PropTypes.string,
     /**
+     * A nonlocalized string that defines the type of interface element represented
+     * by the accessibility element. Used in end-to-end tests.
+     */
+    testRole: React.PropTypes.string,
+    /**
      * Specifies should fonts scale to respect Text Size accessibility setting on iOS.
      * @platform ios
      */
@@ -110,6 +115,7 @@ const Text = React.createClass({
   getDefaultProps(): Object {
     return {
       accessible: true,
+      testRole: 'AXText',
       allowFontScaling: true,
     };
   },

--- a/React/Views/RCTViewManager.m
+++ b/React/Views/RCTViewManager.m
@@ -130,8 +130,9 @@ RCT_EXPORT_MODULE()
 RCT_EXPORT_VIEW_PROPERTY(accessibilityLabel, NSString)
 RCT_EXPORT_VIEW_PROPERTY(accessibilityTraits, UIAccessibilityTraits)
 RCT_EXPORT_VIEW_PROPERTY(backgroundColor, NSColor)
-//RCT_REMAP_VIEW_PROPERTY(accessible, isAccessibilityElement, BOOL)
+RCT_REMAP_VIEW_PROPERTY(accessible, accessibilityElement, BOOL)
 RCT_REMAP_VIEW_PROPERTY(testID, accessibilityIdentifier, NSString)
+RCT_REMAP_VIEW_PROPERTY(testRole, accessibilityRole, NSString)
 RCT_REMAP_VIEW_PROPERTY(backfaceVisibility, layer.doubleSided, css_backface_visibility_t)
 RCT_REMAP_VIEW_PROPERTY(shadowColor, layer.shadowColor, CGColor);
 RCT_REMAP_VIEW_PROPERTY(shadowOffset, layer.shadowOffset, CGSize);


### PR DESCRIPTION
Without this commit, controls like `<Touchable/>` and `<Text/>` is invisible in Accessibility Inspector:
<img width="1028" alt="withoutrole" src="https://cloud.githubusercontent.com/assets/4593681/14097270/dae3c476-f5a1-11e5-9123-fad34eddba44.png">

With this commit:
<img width="1012" alt="withrole" src="https://cloud.githubusercontent.com/assets/4593681/14097321/343adf1e-f5a2-11e5-9237-e79206b98456.png">

