### PR TITLE
Add missing `-lc++` flag for RN 0.26

### DIFF
--- a/Examples/SimpleChatClient/SimpleChatClient.xcodeproj/project.pbxproj
+++ b/Examples/SimpleChatClient/SimpleChatClient.xcodeproj/project.pbxproj
@@ -431,7 +431,10 @@
 				INFOPLIST_FILE = SimpleChatClient/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
-				OTHER_LDFLAGS = "-ObjC";
+				OTHER_LDFLAGS = (
+					"-ObjC",
+					"-lc++",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.elephant.SimpleChatClient;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
@@ -449,7 +452,10 @@
 				INFOPLIST_FILE = SimpleChatClient/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
-				OTHER_LDFLAGS = "-ObjC";
+				OTHER_LDFLAGS = (
+					"-ObjC",
+					"-lc++",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.elephant.SimpleChatClient;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};

--- a/Examples/SimpleGmailClient/SimpleGmailClient.xcodeproj/project.pbxproj
+++ b/Examples/SimpleGmailClient/SimpleGmailClient.xcodeproj/project.pbxproj
@@ -404,7 +404,10 @@
 				);
 				INFOPLIST_FILE = SimpleGmailClient/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
-				OTHER_LDFLAGS = "-ObjC";
+				OTHER_LDFLAGS = (
+					"-ObjC",
+					"-lc++",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.elephant.SimpleGmailClient;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};

--- a/local-cli/generator-osx/templates/xcodeproj/project.pbxproj
+++ b/local-cli/generator-osx/templates/xcodeproj/project.pbxproj
@@ -510,7 +510,10 @@
 				);
 				INFOPLIST_FILE = "<%= name %>/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				OTHER_LDFLAGS = "-ObjC";
+				OTHER_LDFLAGS = (
+					"-ObjC",
+					"-lc++",
+				);
 				PRODUCT_NAME = <%= name %>;
 			};
 			name = Debug;
@@ -526,7 +529,10 @@
 				);
 				INFOPLIST_FILE = "<%= name %>/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				OTHER_LDFLAGS = "-ObjC";
+				OTHER_LDFLAGS = (
+					"-ObjC",
+					"-lc++",
+				);
 				PRODUCT_NAME = <%= name %>;
 			};
 			name = Release;


### PR DESCRIPTION
Currently initial project of `v0.8.3` will thrown following errors:

![2016-05-25 11 09 53](https://cloud.githubusercontent.com/assets/3001525/15545141/d4eb998c-22cd-11e6-984f-0c774f0dffd9.png)